### PR TITLE
chore: bump analyzer

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  analyzer: ^8.4.0
+  analyzer: ^10.0.0
   build: ">=3.0.0 <5.0.0"
   path: ^1.9.1
   source_gen: ">=3.0.0 <5.0.0"


### PR DESCRIPTION
Bumps the analyzer dependency to 10 to allow use with newer (flutter, ...) versions.

All tests pass.